### PR TITLE
bump up grape gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ end
 group :test do
   gem 'rspec', '~> 2.11.0'
   gem 'rr',    '~> 1.0.4'
-  gem 'grape', '= 0.6.0'  # gem collision with jbundler (virtus) if looser
+  gem 'grape', '~> 0.11.0'
   gem 'json'
   gem 'rack-test'
 end

--- a/lib/ostrich-jruby/grape_endpoint.rb
+++ b/lib/ostrich-jruby/grape_endpoint.rb
@@ -10,7 +10,6 @@ module Ostrich
     default_format :json
 
     desc "Get stats from ostrich."
-    set(:name, "stats")
 
     get :stats do
       handler = Ostrich::CommandHandler.new(Ostrich::Stats.collection)

--- a/lib/ostrich-jruby/grape_endpoint.rb
+++ b/lib/ostrich-jruby/grape_endpoint.rb
@@ -9,7 +9,9 @@ module Ostrich
 
     default_format :json
 
-    desc "Get stats from ostrich."
+    desc "Get stats from ostrich." do
+      named: 'stats'
+    end
 
     get :stats do
       handler = Ostrich::CommandHandler.new(Ostrich::Stats.collection)


### PR DESCRIPTION
Hey Cameron,

I'm Yang from the international engineering team. So pity that I haven't got the chance to meet you in person. :O

I'm bumping up the grape gem from 0.6.0 to 0.11.0 to support the nested params. I noticed the comment you put in the Gemfile, but since we have already bumped up `virtus` gem to 1.0.3, the collision is no longer there. 

Also, would you mind if I ask two (dumb) questions here?
1. How to test this gem? I have modified the gem, and it seems working fine.
2. The `set(:name, 'stats')` seems not working in the new grape gem. Why did you add that? I have searched all grape doc, and looks like the `set` is not part of grape. Where is it from?

Thanks,
Yang
